### PR TITLE
Added Support for Limiting Concurrent Sync and Async LLM Calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ async def main():
 markdown_pages = asyncio.run(main())
 ```
 
+The maximum number of concurrent requests made to the LLM can also be controlled via the `AIPDF_MAX_CONCURRENT_REQUESTS` environment variable. By default, there is no limit set.
+
 ##  Ollama
 
 You can use with any ollama multi-modal models 

--- a/src/aipdf/__init__.py
+++ b/src/aipdf/__init__.py
@@ -1,5 +1,5 @@
 from .ocr import ocr, ocr_async
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"
 
 __all__ = ["__version__", "ocr", "ocr_async"]

--- a/src/aipdf/ocr.py
+++ b/src/aipdf/ocr.py
@@ -405,7 +405,7 @@ async def ocr_async(
     semaphore = None
     max_concurrent_requests = os.getenv("AIPDF_MAX_CONCURRENT_REQUESTS", None)
     if max_concurrent_requests:
-        logging.info("The maximum number of concurrent reqests is set to %s", max_concurrent_requests)
+        logging.info("The maximum number of concurrent requests is set to %s", max_concurrent_requests)
         max_concurrent_requests = int(max_concurrent_requests)
         semaphore = asyncio.Semaphore(max_concurrent_requests)
 


### PR DESCRIPTION
This PR enables the number of concurrent API calls made to LLM (through both the sync and async functions) to be limited via the `AIPDF_MAX_CONCURRENT_REQUESTS` environment variable.

This is useful when there are requests limits on the API being used or there are other constraints in place.

Fixes https://linear.app/mindsdb/issue/BE-989/update-aipdf-to-support-limiting-concurrent-requests