### PR TITLE
Update openai dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dependencies = [
     "PyMuPDF==1.25.2",
-    "openai<2.0.0,>=1.58.1",
+    "openai<3.0.0,>=2.0.0",
 ]
 dynamic = ["version"]
 

--- a/src/aipdf/__init__.py
+++ b/src/aipdf/__init__.py
@@ -1,5 +1,5 @@
 from .ocr import ocr, ocr_async
 
-__version__ = "0.0.6.3"
+__version__ = "0.0.7.0"
 
 __all__ = ["__version__", "ocr", "ocr_async"]


### PR DESCRIPTION
Update openai dependency
Higher openai version is required by updated litellm here https://github.com/mindsdb/mindsdb/pull/12021